### PR TITLE
Limit managed memory usage to platforms that support it. Compile for cc75.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 #decide whether to use CUDA or not
 #find_package(CUDAToolkit REQUIRED)
 if(NOT CUDA_COMPUTE_CAPABILITY)
-  set(CUDA_COMPUTE_CAPABILITY 70 80)
+  set(CUDA_COMPUTE_CAPABILITY 70 75 80)
 endif()
 
 #Find OpenMP


### PR DESCRIPTION
Current code uses managed memory on GPU, but not all platforms support this feature. Add runtime check and only use managed memory on platforms that support it. 

Additionally, compiling code for cc75 to support T4 GPUs.